### PR TITLE
fix(color-picker): use slotprops in order to override style

### DIFF
--- a/packages/ui/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/ui/src/components/ColorPicker/ColorPicker.tsx
@@ -2,17 +2,16 @@ import { Box, ClickAwayListener } from "@mui/material";
 import { FC, KeyboardEvent, useState } from "react";
 import { CirclePicker, ColorResult } from "react-color";
 
-import { PickerBackgroundBox, circlePickerStyle } from "./styles";
 import { ColorPickerIcon } from "./ColorPickerIcon";
+import { PickerBackgroundBox, circlePickerStyle } from "./styles";
 import { ColorPickerProps, HexaColor } from "./types";
-
 
 const ColorPicker: FC<ColorPickerProps> = ({
   disabled = false,
   options,
   value,
   onChange,
-  slotProps
+  slotProps,
 }) => {
   const [isCirclePickerVisible, setIsCirclePickerVisible] = useState(false);
 
@@ -32,28 +31,33 @@ const ColorPicker: FC<ColorPickerProps> = ({
   };
 
   return (
-    <ClickAwayListener onClickAway={handleClose}>
+    <ClickAwayListener
+      {...slotProps?.clickAwayListener}
+      onClickAway={handleClose}
+    >
       <PickerBackgroundBox
         disabled={disabled}
         tabIndex={0}
         onKeyDown={handleKeyDown}
+        {...slotProps?.pickerBox}
       >
         <ColorPickerIcon onClick={handlePickerToggle} fill={value} />
-          {isCirclePickerVisible && (
-            <Box sx={circlePickerStyle}>
-              <CirclePicker
-                colors={options}
-                color={value}
-                onChange={(newColor: ColorResult) => {
-                  onChange(newColor.hex as HexaColor);
-                  handleClose();
-                }}
-                circleSize={20}
-                circleSpacing={5}
-                width="15rem"
-              />
-            </Box>
-          )}
+        {isCirclePickerVisible && (
+          <Box {...slotProps?.circlePickerBox} sx={circlePickerStyle}>
+            <CirclePicker
+              colors={options}
+              color={value}
+              onChange={(newColor: ColorResult) => {
+                onChange(newColor.hex as HexaColor);
+                handleClose();
+              }}
+              circleSize={20}
+              circleSpacing={5}
+              width="15rem"
+              {...slotProps?.circlePicker}
+            />
+          </Box>
+        )}
       </PickerBackgroundBox>
     </ClickAwayListener>
   );

--- a/packages/ui/src/components/ColorPicker/types.ts
+++ b/packages/ui/src/components/ColorPicker/types.ts
@@ -1,4 +1,4 @@
-import { ClickAwayListenerProps } from "@mui/material";
+import { BoxProps, ClickAwayListenerProps } from "@mui/material";
 import { SVGAttributes } from "react";
 import { CirclePickerProps } from "react-color";
 
@@ -6,7 +6,9 @@ export type HexaColor = `#${string}`;
 
 export type ColorPickerSlotProps = {
   clickAwayListener?: Omit<ClickAwayListenerProps, "onClickAway" | "children">;
+  pickerBox?: BoxProps;
   circlePicker?: Omit<CirclePickerProps, "colors" | "color" | "onChange">;
+  circlePickerBox?: BoxProps;
 };
 
 export type ColorPickerProps = {


### PR DESCRIPTION
## Describe your changes

This pull request enhances the flexibility of the `ColorPicker` component by introducing customizable slot props for various subcomponents and updating the type definitions accordingly. The changes aim to improve the component's extensibility and integration into different use cases.

### Enhancements to `ColorPicker` component:

* **Customizable slot props for subcomponents:**
  - Updated the `ColorPicker` component to accept `slotProps` for customizing the behavior and styling of `ClickAwayListener`, `PickerBackgroundBox`, `Box` wrapping the `CirclePicker`, and the `CirclePicker` itself. (`packages/ui/src/components/ColorPicker/ColorPicker.tsx`, [[1]](diffhunk://#diff-eb212f101643493b4a707e1300585e71d3ce3a90be4d0fc1f066601f628ee2a1L35-R46) [[2]](diffhunk://#diff-eb212f101643493b4a707e1300585e71d3ce3a90be4d0fc1f066601f628ee2a1R57)
  - Passed the new `slotProps` properties to the corresponding subcomponents, allowing for greater control over their attributes. (`packages/ui/src/components/ColorPicker/ColorPicker.tsx`, [[1]](diffhunk://#diff-eb212f101643493b4a707e1300585e71d3ce3a90be4d0fc1f066601f628ee2a1L35-R46) [[2]](diffhunk://#diff-eb212f101643493b4a707e1300585e71d3ce3a90be4d0fc1f066601f628ee2a1R57)

* **Type definition updates:**
  - Extended the `ColorPickerSlotProps` type to include new properties: `pickerBox`, `circlePicker`, and `circlePickerBox`, ensuring type safety for the newly added slot props. (`packages/ui/src/components/ColorPicker/types.ts`, [packages/ui/src/components/ColorPicker/types.tsL1-R11](diffhunk://#diff-778c3aea420347619dc4bca823d79fab0952cf236d7c125d055dea04b67cb54cL1-R11))

These changes improve the reusability and customization of the `ColorPicker` component, making it more adaptable to diverse application requirements.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)