### PR TITLE
feat(ui): allow ReactNode for EmptyState props

### DIFF
--- a/packages/ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState/EmptyState.tsx
@@ -22,8 +22,8 @@ export type EmptyStateProps = (
     }
 ) & {
   imageHeight?: string | number;
-  title: string;
-  description?: string;
+  title: ReactNode;
+  description?: ReactNode;
   footer?: ReactNode;
   slotProps?: {
     root?: StackProps;
@@ -73,7 +73,6 @@ const EmptyState: FC<EmptyStateProps> = ({
       </Box>
       <Typography
         variant="h2"
-        fontWeight={500}
         mt={3}
         {...(slotProps.title ?? titleProps)}
       >


### PR DESCRIPTION
## Describe your changes

Updated two props of the `EmptyState` component to accept `ReactNode` instead of `string`.

This change makes the component more flexible by allowing richer content such as icons, formatted text, or custom components, instead of being limited to plain strings.

No breaking visual changes are expected; existing string values continue to work as before.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)